### PR TITLE
superblock: Convert to snafu and split up the Error type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,13 +749,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
+name = "snafu"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "superblock"
 version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+ "snafu",
  "test-log",
- "thiserror 2.0.12",
  "uuid",
  "zerocopy",
  "zstd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ nix = { version = "0.30.1", features = ["fs", "mount"] }
 phf = "0.11"
 serde = { version = "1.0" }
 serde_json = "1.0"
+snafu = "0.8.5"
 test-log = "0.2.17"
 thiserror = "2.0.3"
 uuid = { version = "1.12.1", features = ["v8"] }

--- a/crates/superblock/Cargo.toml
+++ b/crates/superblock/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-thiserror.workspace = true
+snafu.workspace = true
 uuid = { workspace = true, features = ["v8"] }
 zerocopy = { workspace = true, features = ["derive", "std"] }
 

--- a/crates/superblock/src/btrfs.rs
+++ b/crates/superblock/src/btrfs.rs
@@ -7,7 +7,7 @@
 //! This module provides functionality for reading and parsing BTRFS filesystem superblocks,
 //! which contain critical metadata about the filesystem including UUIDs and labels.
 
-use crate::{Detection, Error};
+use crate::{Detection, UnicodeError};
 use uuid::Uuid;
 use zerocopy::*;
 
@@ -117,12 +117,12 @@ impl Detection for Btrfs {
 
 impl Btrfs {
     /// Return the encoded UUID for this superblock as a string
-    pub fn uuid(&self) -> Result<String, Error> {
+    pub fn uuid(&self) -> Result<String, UnicodeError> {
         Ok(Uuid::from_bytes(self.fsid).hyphenated().to_string())
     }
 
     /// Return the volume label as a string
-    pub fn label(&self) -> Result<String, Error> {
+    pub fn label(&self) -> Result<String, UnicodeError> {
         Ok(str::from_utf8(&self.label)?.trim_end_matches('\0').to_owned())
     }
 }

--- a/crates/superblock/src/ext4.rs
+++ b/crates/superblock/src/ext4.rs
@@ -8,7 +8,7 @@
 //! The superblock contains critical metadata about the filesystem including UUID, volume label,
 //! and various configuration parameters.
 
-use crate::{Detection, Error};
+use crate::{Detection, UnicodeError};
 use uuid::Uuid;
 use zerocopy::*;
 
@@ -209,12 +209,12 @@ impl Detection for Ext4 {
 
 impl Ext4 {
     /// Return the encoded UUID for this superblock
-    pub fn uuid(&self) -> Result<String, Error> {
+    pub fn uuid(&self) -> Result<String, UnicodeError> {
         Ok(Uuid::from_bytes(self.uuid).hyphenated().to_string())
     }
 
     /// Return the volume label as valid utf8
-    pub fn label(&self) -> Result<String, super::Error> {
+    pub fn label(&self) -> Result<String, UnicodeError> {
         Ok(str::from_utf8(&self.volume_name)?.into())
     }
 }

--- a/crates/superblock/src/f2fs.rs
+++ b/crates/superblock/src/f2fs.rs
@@ -13,7 +13,7 @@
 //! - Encryption settings
 //! - Device information
 
-use crate::{Detection, Error};
+use crate::{Detection, UnicodeError};
 use uuid::Uuid;
 use zerocopy::*;
 
@@ -163,14 +163,14 @@ pub const START_POSITION: u64 = 1024;
 
 impl F2FS {
     /// Returns the filesystem UUID as a hyphenated string
-    pub fn uuid(&self) -> Result<String, Error> {
+    pub fn uuid(&self) -> Result<String, UnicodeError> {
         Ok(Uuid::from_bytes(self.uuid).hyphenated().to_string())
     }
 
     /// Returns the volume label as a UTF-16 decoded string
     ///
     /// Handles null termination and invalid UTF-16 sequences
-    pub fn label(&self) -> Result<String, Error> {
+    pub fn label(&self) -> Result<String, UnicodeError> {
         // Convert the array of U16<LittleEndian> to u16
         let vol = self.volume_name.map(|x| x.get());
         let prelim_label = String::from_utf16(&vol)?;

--- a/crates/superblock/src/fat.rs
+++ b/crates/superblock/src/fat.rs
@@ -10,7 +10,7 @@
 //! - Volume name and UUID
 //! - Encryption settings
 
-use crate::{Detection, Error};
+use crate::{Detection, UnicodeError};
 use zerocopy::*;
 
 /// Starting position of superblock in bytes
@@ -130,7 +130,7 @@ impl Fat {
     }
 
     /// Returns the filesystem id
-    pub fn uuid(&self) -> Result<String, Error> {
+    pub fn uuid(&self) -> Result<String, UnicodeError> {
         Ok(match self.fat_type() {
             FatType::Fat16 => vol_id(self.fat16().common.vol_id),
             FatType::Fat32 => vol_id(self.fat32().common.vol_id),
@@ -138,7 +138,7 @@ impl Fat {
     }
 
     /// Returns the volume label
-    pub fn label(&self) -> Result<String, Error> {
+    pub fn label(&self) -> Result<String, UnicodeError> {
         match self.fat_type() {
             FatType::Fat16 => vol_label(&self.fat16().common.vol_label),
             FatType::Fat32 => vol_label(&self.fat32().common.vol_label),
@@ -163,7 +163,7 @@ fn first_n_bytes<const N: usize, const M: usize>(arr: &[u8; M]) -> &[u8; N] {
     <&[u8; N]>::try_from(&arr[..N]).unwrap()
 }
 
-fn vol_label(vol_label: &[u8; 11]) -> Result<String, Error> {
+fn vol_label(vol_label: &[u8; 11]) -> Result<String, UnicodeError> {
     Ok(String::from_utf8_lossy(vol_label).trim_end_matches(' ').to_string())
 }
 

--- a/crates/superblock/src/fat.rs
+++ b/crates/superblock/src/fat.rs
@@ -120,26 +120,26 @@ pub enum FatType {
 }
 
 impl Fat {
-    pub fn fat_type(&self) -> Result<FatType, Error> {
+    pub fn fat_type(&self) -> FatType {
         // this is how the linux kernel does it in https://github.com/torvalds/linux/blob/master/fs/fat/inode.c
         if self.fat_length == 0 && self.fat32().fat32_length != 0 {
-            Ok(FatType::Fat32)
+            FatType::Fat32
         } else {
-            Ok(FatType::Fat16)
+            FatType::Fat16
         }
     }
 
     /// Returns the filesystem id
     pub fn uuid(&self) -> Result<String, Error> {
-        match self.fat_type()? {
+        Ok(match self.fat_type() {
             FatType::Fat16 => vol_id(self.fat16().common.vol_id),
             FatType::Fat32 => vol_id(self.fat32().common.vol_id),
-        }
+        })
     }
 
     /// Returns the volume label
     pub fn label(&self) -> Result<String, Error> {
-        match self.fat_type()? {
+        match self.fat_type() {
             FatType::Fat16 => vol_label(&self.fat16().common.vol_label),
             FatType::Fat32 => vol_label(&self.fat32().common.vol_label),
         }
@@ -167,6 +167,6 @@ fn vol_label(vol_label: &[u8; 11]) -> Result<String, Error> {
     Ok(String::from_utf8_lossy(vol_label).trim_end_matches(' ').to_string())
 }
 
-fn vol_id(vol_id: U32<LittleEndian>) -> Result<String, Error> {
-    Ok(format!("{:04X}-{:04X}", vol_id >> 16, vol_id & 0xFFFF))
+fn vol_id(vol_id: U32<LittleEndian>) -> String {
+    format!("{:04X}-{:04X}", vol_id >> 16, vol_id & 0xFFFF)
 }

--- a/crates/superblock/src/luks2.rs
+++ b/crates/superblock/src/luks2.rs
@@ -11,8 +11,28 @@
 //! like encryption parameters, key slots and segment information in JSON format.
 //!
 
+use std::io;
+
+use snafu::Snafu;
+
 mod config;
 mod superblock;
 
 pub use config::*;
 pub use superblock::*;
+
+/// Errors that can occur when parsing LUKS config
+#[derive(Debug, Snafu)]
+pub enum ConfigError {
+    /// An I/O error occurred
+    #[snafu(display("io"))]
+    Io { source: io::Error },
+
+    /// Invalid JSON
+    #[snafu(display("invalid json"))]
+    InvalidJson { source: serde_json::Error },
+
+    /// Error decoding UTF-8 string data
+    #[snafu(display("invalid utf8 in decode"))]
+    InvalidUtf8 { source: std::str::Utf8Error },
+}

--- a/crates/superblock/src/xfs.rs
+++ b/crates/superblock/src/xfs.rs
@@ -12,7 +12,7 @@
 //! - Quota tracking data
 //! - Log and realtime extent details
 
-use crate::Detection;
+use crate::{Detection, UnicodeError};
 use uuid::Uuid;
 use zerocopy::*;
 
@@ -166,12 +166,12 @@ pub const MAGIC: U32<BigEndian> = U32::new(0x58465342);
 
 impl Xfs {
     /// Returns the filesystem UUID as a properly formatted string
-    pub fn uuid(&self) -> Result<String, super::Error> {
+    pub fn uuid(&self) -> Result<String, UnicodeError> {
         Ok(Uuid::from_bytes(self.uuid).hyphenated().to_string())
     }
 
     /// Returns the volume label as a UTF-8 string, trimming any null termination
-    pub fn label(&self) -> Result<String, super::Error> {
+    pub fn label(&self) -> Result<String, UnicodeError> {
         Ok(str::from_utf8(&self.fname)?.trim_end_matches('\0').to_owned())
     }
 }


### PR DESCRIPTION
Not terribly exciting. I probably wouldn't switch this crate to snafu if we weren't trying to convert all uses of thiserror to snafu.